### PR TITLE
giving each status of pending and approved event differnt colors fixed #61

### DIFF
--- a/client/src/components/Calendar/index.js
+++ b/client/src/components/Calendar/index.js
@@ -51,6 +51,13 @@ class BigCalendar extends Component {
     history.push({ pathname: "/detailsevent", event });
   };
 
+  pendingEventStyle = (event, start, end, isSelected) => {
+    if (event.status === 0) {
+      const style = { backgroundColor: "#D4AC0D" };
+      return { style: style };
+    }
+  };
+
   render() {
     const localizer = Calendar.momentLocalizer(moment);
     const { events, loading } = this.state;
@@ -74,6 +81,7 @@ class BigCalendar extends Component {
               style={{ height: "100vh" }}
               onSelectEvent={this.detailsEvent}
               onSelectSlot={this.bookEvent}
+              eventPropGetter={this.pendingEventStyle}
             />
           </div>
         </div>

--- a/client/src/components/Calendar/index.js
+++ b/client/src/components/Calendar/index.js
@@ -51,7 +51,7 @@ class BigCalendar extends Component {
     history.push({ pathname: "/detailsevent", event });
   };
 
-  pendingEventStyle = (event, start, end, isSelected) => {
+  pendingEventStyle = event => {
     if (event.status === 0) {
       const style = { backgroundColor: "#D4AC0D" };
       return { style: style };

--- a/client/src/components/SideBar/index.js
+++ b/client/src/components/SideBar/index.js
@@ -16,7 +16,7 @@ const SideBar = () => (
           <p className="agenda-prop">approved</p>
         </div>
         <div className="color-typing">
-          <div className="light-blue" />
+          <div className="yellow" />
           <p className="agenda-prop">pending</p>
         </div>
       </div>

--- a/client/src/components/SideBar/sidebar.css
+++ b/client/src/components/SideBar/sidebar.css
@@ -26,7 +26,7 @@
 }
 
 .blue,
-.light-blue {
+.yellow {
   width: 10px;
   height: 10px;
   background: #c4c4c4;
@@ -39,11 +39,11 @@
   margin-top: 20px;
 }
 .blue {
-  background: #719ceb;
+  background: #3174ad;
 }
 
-.light-blue {
-  background: #65c6c4;
+.yellow {
+  background: #d4ac0d;
 }
 .agenda-prop {
   font-size: 12px;


### PR DESCRIPTION
- [x] change the event color with status pending to yellow in calendar.

- [x] change the pending color with the same yellow too on the SideBar component as they must be the same.

- [x] change the blue color for the approved status on the SideBar component to be the same as the blue default color on the calendar