### PR TITLE
Remove agenda/month options in calendar component

### DIFF
--- a/client/src/components/Calendar/index.js
+++ b/client/src/components/Calendar/index.js
@@ -70,6 +70,7 @@ class BigCalendar extends Component {
               localizer={localizer}
               defaultDate={new Date()}
               defaultView={"week"}
+              views={['week','day']}
               events={events}
               style={{ height: "100vh" }}
               onSelectEvent={this.detailsEvent}


### PR DESCRIPTION
- [X] Remove agenda/month options in calendar component, by adding `views` prop to the calendar props which `views = {['week','day']}`

related to #65 #13